### PR TITLE
[DEVOPS] Exlusión de actualización TelegramBot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "python-telegram-bot"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Se excluye de `dependabot` la dependencia de `python-telegram-bot`